### PR TITLE
Gmail senders: drop the "existing gws config directory" field

### DIFF
--- a/frontend/src/components/workflow/bots/GmailNotifications.tsx
+++ b/frontend/src/components/workflow/bots/GmailNotifications.tsx
@@ -16,7 +16,6 @@ type GmailNotificationsBots = Pick<WorkflowBots,
   | 'gmailBlockedDefaults' | 'gmailDefaultIsBlocked' | 'gmailTestPassed' | 'gmailHasChanges' | 'loadGmail' | 'saveGmail' | 'testGmail'
   | 'gmailConnections' | 'gmailConnectionsBusy' | 'gmailAuthPending'
   | 'gmailNewConnectionName' | 'setGmailNewConnectionName'
-  | 'gmailNewConnectionDir' | 'setGmailNewConnectionDir'
   | 'runGmailConnectionAction' | 'connectGmailAccount'
 >
 
@@ -28,7 +27,6 @@ export function GmailNotifications({ bots }: { bots: GmailNotificationsBots }) {
     gmailBlockedDefaults, gmailDefaultIsBlocked, gmailTestPassed, gmailHasChanges, loadGmail, saveGmail, testGmail,
     gmailConnections, gmailConnectionsBusy, gmailAuthPending,
     gmailNewConnectionName, setGmailNewConnectionName,
-    gmailNewConnectionDir, setGmailNewConnectionDir,
     runGmailConnectionAction, connectGmailAccount,
   } = bots
 
@@ -184,26 +182,15 @@ export function GmailNotifications({ bots }: { bots: GmailNotificationsBots }) {
                       onClick={() => runGmailConnectionAction('new', async () => {
                         await agentApi.createGmailConnection({
                           display_name: gmailNewConnectionName.trim(),
-                          config_home: gmailNewConnectionDir.trim() || undefined,
                         })
                         setGmailNewConnectionName('')
-                        setGmailNewConnectionDir('')
                       })}
                     >
                       Add account
                     </Button>
                   </div>
-                  <input
-                    type="text"
-                    value={gmailNewConnectionDir}
-                    onChange={event => setGmailNewConnectionDir(event.target.value)}
-                    disabled={readOnly}
-                    placeholder="Existing gws config directory (optional)"
-                    className="w-full rounded-md border border-border bg-background px-3 py-2 font-mono text-xs focus:outline-none focus:ring-2 focus:ring-primary"
-                  />
                   <p className="text-xs text-muted-foreground">
                     Add the account, then click <strong>Sign in with Google</strong> on its row to authorize it in your browser.
-                    The directory field is only needed to adopt a <code>gws</code> profile already authenticated on the host.
                   </p>
                 </div>
               </Card>

--- a/frontend/src/components/workflow/bots/useWorkflowBots.ts
+++ b/frontend/src/components/workflow/bots/useWorkflowBots.ts
@@ -110,9 +110,6 @@ export function useWorkflowBots(workspacePath: string | null) {
   const [gmailConnections, setGmailConnections] = useState<GmailConnection[]>([])
   const [gmailConnectionsBusy, setGmailConnectionsBusy] = useState<string | null>(null)
   const [gmailNewConnectionName, setGmailNewConnectionName] = useState('')
-  // Optional: adopt a gws config directory that is ALREADY authenticated on the
-  // host, instead of signing in through the browser.
-  const [gmailNewConnectionDir, setGmailNewConnectionDir] = useState('')
   // Set while a Google sign-in is in flight, so the row can say it is waiting.
   const [gmailAuthPending, setGmailAuthPending] = useState<string | null>(null)
   const [gmailTestedTo, setGmailTestedTo] = useState<string | null>(null)
@@ -672,7 +669,6 @@ export function useWorkflowBots(workspacePath: string | null) {
     // gmail senders (multi-account)
     gmailConnections, gmailConnectionsBusy, gmailAuthPending,
     gmailNewConnectionName, setGmailNewConnectionName,
-    gmailNewConnectionDir, setGmailNewConnectionDir,
     loadGmailConnections, runGmailConnectionAction, connectGmailAccount,
   }
 }


### PR DESCRIPTION
The multi-account sender work from this branch is already on `main` (fd122a97c, plus the follow-up d06e47759). This branch is rebased onto current `main` and now carries one follow-up change.

The Add-account form had a second input asking for a gws config directory to adopt. It was only ever useful to an operator who had already run `gws auth login` by hand in a custom `GOOGLE_WORKSPACE_CLI_CONFIG_DIR` — which browser sign-in made unnecessary, since every account added through the UI gets a private directory provisioned for it. Sitting next to the button that does the same job correctly, it asked users for a path they have no reason to have.

The API still accepts `config_home`, so an adopted directory can be set directly, and the migration that carries a pre-existing single-account install onto a connection is unchanged. Only the input and its dead state are gone.

Verified with `tsc --noEmit` clean.

Refs #188