### PR TITLE
Offer the Gmail sign-in link as copyable text, so it survives a Chrome profile switch

### DIFF
--- a/frontend/src/components/workflow/bots/GmailNotifications.tsx
+++ b/frontend/src/components/workflow/bots/GmailNotifications.tsx
@@ -14,7 +14,7 @@ type GmailNotificationsBots = Pick<WorkflowBots,
   | 'gmailOpen' | 'setGmailOpen' | 'gmailConfig' | 'setGmailConfig' | 'gmailBlockedText' | 'setGmailBlockedText'
   | 'gmailLoading' | 'gmailChecking' | 'gmailSaving' | 'gmailTesting' | 'gmailError' | 'gmailSuccess' | 'gmailTestResult'
   | 'gmailBlockedDefaults' | 'gmailDefaultIsBlocked' | 'gmailCanEnable' | 'gmailHasChanges' | 'loadGmail' | 'saveGmail' | 'testGmail'
-  | 'gmailConnections' | 'gmailConnectionsBusy' | 'gmailAuthPending'
+  | 'gmailConnections' | 'gmailConnectionsBusy' | 'gmailAuthPending' | 'gmailAuthUrl'
   | 'gmailNewConnectionName' | 'setGmailNewConnectionName'
   | 'gmailNewConnectionDir' | 'setGmailNewConnectionDir'
   | 'runGmailConnectionAction' | 'connectGmailAccount'
@@ -26,7 +26,7 @@ export function GmailNotifications({ bots }: { bots: GmailNotificationsBots }) {
     gmailOpen, setGmailOpen, gmailConfig, setGmailConfig, gmailBlockedText, setGmailBlockedText,
     gmailLoading, gmailChecking, gmailSaving, gmailTesting, gmailError, gmailSuccess, gmailTestResult,
     gmailBlockedDefaults, gmailDefaultIsBlocked, gmailCanEnable, gmailHasChanges, loadGmail, saveGmail, testGmail,
-    gmailConnections, gmailConnectionsBusy, gmailAuthPending,
+    gmailConnections, gmailConnectionsBusy, gmailAuthPending, gmailAuthUrl,
     gmailNewConnectionName, setGmailNewConnectionName,
     gmailNewConnectionDir, setGmailNewConnectionDir,
     runGmailConnectionAction, connectGmailAccount,
@@ -162,6 +162,28 @@ export function GmailNotifications({ bots }: { bots: GmailNotificationsBots }) {
                             Remove
                           </button>
                         </div>
+
+                        {gmailAuthPending === conn.id && gmailAuthUrl && (
+                          <div className="mt-2 rounded-md border border-border bg-muted/40 p-2">
+                            <p className="text-xs text-muted-foreground">
+                              A tab opened in your default Chrome profile. If this mailbox lives in a
+                              different profile, open that profile and paste this link there — copying
+                              the address bar out of the tab that opened will not work, because Google
+                              ties it to the profile it started in.
+                            </p>
+                            <div className="mt-1.5 flex items-center gap-2">
+                              <code className="flex-1 truncate rounded bg-background px-2 py-1 font-mono text-[11px] text-muted-foreground">
+                                {gmailAuthUrl}
+                              </code>
+                              <button
+                                onClick={() => navigator.clipboard?.writeText(gmailAuthUrl)}
+                                className="shrink-0 rounded border border-border px-2 py-1 text-xs text-muted-foreground hover:text-foreground"
+                              >
+                                Copy link
+                              </button>
+                            </div>
+                          </div>
+                        )}
                       </li>
                     ))}
                   </ul>

--- a/frontend/src/components/workflow/bots/GmailSetupGuide.tsx
+++ b/frontend/src/components/workflow/bots/GmailSetupGuide.tsx
@@ -153,6 +153,14 @@ mv ~/Downloads/client_secret_*.json ~/.config/gws/client_secret.json`}</Cmd>
                 <strong>Add account</strong>, then <strong>Sign in with Google</strong> on its row. Repeat for each
                 mailbox — steps 1&ndash;7 are never needed again.
               </p>
+              <Gotcha>
+                The tab opens in whichever Chrome profile is frontmost. If the mailbox belongs to a different
+                profile, open that profile first and use <strong>Copy link</strong> on the row to paste the sign-in
+                link into it. Do not copy the URL out of the address bar of the tab that opened — by then Chrome has
+                followed Google&rsquo;s redirects, and that URL carries a token tied to the profile it started in.
+                Pasting it elsewhere fails with a bare{' '}
+                <code>400. That&rsquo;s an error. The server cannot process the request because it is malformed.</code>
+              </Gotcha>
             </Step>
           </ol>
 

--- a/frontend/src/components/workflow/bots/useWorkflowBots.ts
+++ b/frontend/src/components/workflow/bots/useWorkflowBots.ts
@@ -115,6 +115,15 @@ export function useWorkflowBots(workspacePath: string | null) {
   const [gmailNewConnectionDir, setGmailNewConnectionDir] = useState('')
   // Set while a Google sign-in is in flight, so the row can say it is waiting.
   const [gmailAuthPending, setGmailAuthPending] = useState<string | null>(null)
+  // The authorize URL handed to the browser, kept so the UI can offer it as
+  // copyable text. openExternal lands in whichever Chrome profile is frontmost,
+  // which is often not the profile holding the mailbox being connected. Copying
+  // the address bar out of that tab does not work: by then Chrome has followed
+  // Google's redirects and the bar holds a /signin/oauth/v3/consent?part=… URL
+  // whose continuation token is bound to the originating profile's cookies —
+  // pasting it into another profile fails with a bare "400 ... malformed".
+  // Only this original authorize URL is safe to paste anywhere.
+  const [gmailAuthUrl, setGmailAuthUrl] = useState<string | null>(null)
   const [gmailTestedTo, setGmailTestedTo] = useState<string | null>(null)
   const [gmailOpen, setGmailOpen] = useState(false)
 
@@ -211,7 +220,9 @@ export function useWorkflowBots(workspacePath: string | null) {
     try {
       setGmailError(null)
       setGmailAuthPending(id)
+      setGmailAuthUrl(null)
       const { auth_url } = await agentApi.startGmailConnectionAuth(id)
+      setGmailAuthUrl(auth_url)
 
       const electronAPI = (window as unknown as {
         electronAPI?: { openExternal?: (url: string) => void }
@@ -223,15 +234,21 @@ export function useWorkflowBots(workspacePath: string | null) {
       if (!electronAPI?.openExternal && !popup) {
         setGmailError('Allow pop-ups for this app, then try connecting again.')
         setGmailAuthPending(null)
+        setGmailAuthUrl(null)
         return
       }
 
       // The callback lands on the server, not in this document, so there is no
       // event here to listen for — and with an external browser there is no
       // window to watch closing either. Poll until the server reports ready.
+      //
+      // The window matches the server's 15-minute pending-state TTL rather than
+      // guessing shorter. Anyone whose mailbox lives in a different Chrome
+      // profile has to open that profile and paste the link across, and giving
+      // up while the server would still accept the callback strands them.
       const startedAt = Date.now()
       const timer = window.setInterval(async () => {
-        const timedOut = Date.now() - startedAt > 3 * 60 * 1000
+        const timedOut = Date.now() - startedAt > 15 * 60 * 1000
         if (popup && !popup.closed && !timedOut) return
 
         const data = await agentApi.listGmailConnections().catch(() => null)
@@ -240,11 +257,13 @@ export function useWorkflowBots(workspacePath: string | null) {
 
         window.clearInterval(timer)
         setGmailAuthPending(null)
+        setGmailAuthUrl(null)
         if (!connected) setGmailError('Sign-in did not complete. Try connecting again.')
         await loadGmailConnections()
       }, 1500)
     } catch (error) {
       setGmailAuthPending(null)
+      setGmailAuthUrl(null)
       setGmailError(error instanceof Error ? error.message : 'Could not start Google sign-in')
     }
   }, [loadGmailConnections])
@@ -686,7 +705,7 @@ export function useWorkflowBots(workspacePath: string | null) {
     gmailLoading, gmailChecking, gmailSaving, gmailTesting, gmailError, gmailSuccess, gmailTestResult,
     gmailBlockedDefaults, gmailDefaultIsBlocked, gmailTestPassed, gmailCanEnable, gmailHasChanges, loadGmail, saveGmail, testGmail,
     // gmail senders (multi-account)
-    gmailConnections, gmailConnectionsBusy, gmailAuthPending,
+    gmailConnections, gmailConnectionsBusy, gmailAuthPending, gmailAuthUrl,
     gmailNewConnectionName, setGmailNewConnectionName,
     gmailNewConnectionDir, setGmailNewConnectionDir,
     loadGmailConnections, runGmailConnectionAction, connectGmailAccount,


### PR DESCRIPTION
## The bug

Connecting a mailbox fails with a bare `400. That's an error. The server cannot process the request because it is malformed.` whenever the mailbox belongs to a Chrome profile other than the one the sign-in tab opened in.

`openExternal` hands the URL to Chrome, which routes it to its most-recently-used window — not necessarily the profile holding the mailbox. It reliably lands in the wrong profile when the right one's window is parked on another macOS Space, since the MRU window is then the one on the current Space.

People recover by copying the URL into the correct profile. That is where it breaks: by then Chrome has followed Google's redirects and the address bar holds `/signin/oauth/v3/consent?...&part=...`, whose continuation token is bound to the originating profile's cookies. Pasting it into another profile produces the 400.

The authorize URL itself carries no such binding and opens in any profile — but the hook was discarding it immediately after handing it to the browser, so there was nothing correct left to copy.

## The fix

- `useWorkflowBots.ts` keeps `auth_url` in state for the life of the flow, cleared on every terminal path (connected, timed out, popup blocked, error).
- `GmailNotifications.tsx` renders it on the connection row while a sign-in is pending, with a **Copy link** button and a note that copying the address bar will not work.
- Poll timeout raised from 3 to 15 minutes, matching the server's `gmailOAuthPendingTTL`. Opening a second Chrome profile and pasting a link takes longer than three minutes, and the old window gave up while the server would still have accepted the callback.
- `GmailSetupGuide.tsx` gains the same warning under "Add your mailboxes", quoting the 400 verbatim so it is findable by the text people actually see.

No server-side change. `BeginGmailOAuth` and the callback handler are untouched.

## Ruled out along the way

Worth recording, since each looked plausible and cost a probe against the live Google endpoint with the real client:

- **The authorize params.** Google accepts the exact URL `BeginGmailOAuth` builds — 200, sign-in renders. `prompt=select_account consent`, `access_type=offline` and the three scopes are all fine.
- **`ApprovalForce` colliding with the `prompt` override.** `oauth2` v0.36.0 defines `ApprovalForce` as `prompt=consent`, and `url.Values.Set` makes the later `SetAuthURLParam` win, so only one `prompt` goes out. Sending both `approval_prompt` and `prompt` *does* fail, but we never send both.
- **A loopback redirect URI with a path.** `http://localhost:PORT/api/human-feedback/gmail/auth/callback` reaches consent and returns a code. Only non-loopback hosts are rejected, with a specific `redirect_uri_mismatch` page.
- **The consent screen configuration.** It renders and issues codes.

None of these produce the generic malformed 400 — bad parameters produce Google's specific "Access blocked" page instead. A curl repro is also signed out, which makes `select_account` a silent no-op, so this does not reproduce outside a real browser session.

## Testing

`npx tsc --noEmit` passes. Verified manually against a live Google OAuth client: the flow completes when the link is pasted into a second Chrome profile, including one whose window is on another macOS Space.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NprD12Hj8woEA9wxeVxxTw